### PR TITLE
Add snap configuration for port and userpass variables

### DIFF
--- a/bin/launch-ladder
+++ b/bin/launch-ladder
@@ -1,0 +1,13 @@
+#!/bin/sh -e
+
+port="$(snapctl get port)"
+if [ -n "$port" ]; then
+	export PORT="$port"
+fi
+
+userpass="$(snapctl get userpass)"
+if [ -n "$userpass" ]; then
+	export USERPASS="$userpass"
+fi
+
+ladder

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,0 +1,24 @@
+#!/bin/sh -e
+
+# Get new port value
+port="$(snapctl get port)"
+
+# Validate it
+if ! expr "$port" : '^[1-9][0-9]*$' > /dev/null; then
+	echo "\"$port\" is not a valid port number" >&2
+	exit 1
+fi
+
+# Get new username:pasword pair
+userpass="$(snapctl get userpass)"
+
+# Validate it
+if [ -n "$userpass" ]; then
+	if [ -z "$(echo "$userpass" | cut -sd ':' -f 1)" ] \
+	|| [ -z "$(echo "$userpass" | cut -sd ':' -f 2)" ]; then
+		echo "\"$userpass\" is not a valid username:password value" >&2
+		exit 1
+	fi
+fi
+
+snapctl restart ladder

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,0 +1,13 @@
+#!/bin/sh -e
+
+# Check if port value is currently unset, and if so, set it to 8080.
+#
+# The gadget snap may have set a value for the port, but if not, ensure it is
+# set. Use port 8080 as a default value.
+
+port="$(snapctl get port)"
+
+# Initialize port if it's not set
+if [ -z "$port" ]; then
+	snapctl set port=8080
+fi

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -1,0 +1,17 @@
+#!/bin/sh -e
+
+# Check if port value is currently unset, and if so, set to 8080.
+#
+# On a fresh install, the install hook should set the port to the default
+# value (or have already been set by the gadget snap), but if we're refreshing
+# from a version which does not support a configurable port to one which does,
+# the install hook does not run, so the configure hook would see the empty port
+# setting and fail, reverting the refresh. To avoid this, ensure that after the
+# refresh occurs, a port is set for the new revision so the configure hook
+# triggered by the refresh will succeed as well.
+
+port="$(snapctl get port)"
+
+if [ -z "$port" ]; then
+	snapctl set port=8080
+fi

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -11,9 +11,15 @@ description: |
   Selfhosted alternative to 12ft.io. and 1ft.io bypass paywalls with
   a proxy ladder and remove CORS headers from any URL
 
-  This snap runs on port 8080, so once installed, point your browser at 
-  https://localhost:8080 - or whatever host it's running on.
-  
+  By default, this snap runs on port 8080, so once installed, point your
+  browser at https://localhost:8080 - or whatever host it's running on.
+
+  The port can be configured by running `sudo snap set ladder port=somenumber`
+  for the port number of your choice.
+
+  Additionally, password authentication can be enabled by setting a username
+  and password via `sudo snap set ladder userpass=someusername:somepassword`.
+
   This snap is maintained by Alan Pope, and is not
   necessarily endorsed or officially maintained by the upstream developers.
 
@@ -64,11 +70,15 @@ parts:
       # So for now we use build, which builds binaries for all architectures and OS
       # but we only take the one for this arch we are building on
       goreleaser build
-      install dist/ladder_linux_$SNAP_ARCH*/ladder $SNAPCRAFT_PART_INSTALL
+      mkdir -p $SNAPCRAFT_PART_INSTALL/bin
+      install dist/ladder_linux_$SNAP_ARCH*/ladder $SNAPCRAFT_PART_INSTALL/bin
+  scripts:
+    plugin: dump
+    source: bin/
 
 apps:
   ladder:
-    command: ladder
+    command: launch-ladder
     daemon: simple
     plugs:
       - network


### PR DESCRIPTION
The upstream ladder project supports setting [various configuration options](https://github.com/everywall/ladder?tab=readme-ov-file#environment-variables), such as port and username/password, via environment variables.

This PR adds snap hooks to handle configuration values for `port` and `userpass`, which set the set the port on which the application will listen, and define a username and password pair for basic authentication, respectively. Basic validation is performed as part of the configure hook to check that the values seem sensible.

If these snap configuration values are set, they are used to construct the `PORT` and `USERPASS` environment variables, which are then exported to be accessible to the `ladder` binary via a wrapper script.

The wrapper script needs to be able to find the `ladder` binary in the path, so this commit changes its install location to `bin/ladder`, rather than directly in the root of the snap.