### PR TITLE
Add snap configuration for port and userpass

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,0 +1,9 @@
+#!/bin/bash
+PORT=$(snapctl get port)
+if [ -n "$PORT" ]; then
+  if ! echo "$PORT" | grep -qE '^[0-9]+$' || [ "$PORT" -lt 1 ] || [ "$PORT" -gt 65535 ]; then
+    echo "Invalid port: must be a number between 1 and 65535"
+    exit 1
+  fi
+fi
+snapctl restart ladder 2>/dev/null || true

--- a/snap/local/ladder-launch
+++ b/snap/local/ladder-launch
@@ -1,0 +1,10 @@
+#!/bin/bash
+PORT=$(snapctl get port)
+USERPASS=$(snapctl get userpass)
+
+export PORT="${PORT:-8080}"
+if [ -n "$USERPASS" ]; then
+  export USERPASS="$USERPASS"
+fi
+
+exec "$SNAP/ladder"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,4 +1,5 @@
 name: ladder
+title: Ladder
 base: core24
 version: '0.0.22'
 license: GPL-3.0
@@ -11,9 +12,20 @@ description: |
   Selfhosted alternative to 12ft.io. and 1ft.io bypass paywalls with
   a proxy ladder and remove CORS headers from any URL
 
-  This snap runs on port 8080, so once installed, point your browser at 
-  https://localhost:8080 - or whatever host it's running on.
-  
+  This snap runs on port 8080 by default. You can change the port with:
+
+    snap set ladder port=9090
+
+  To require Basic Auth (username:password), set:
+
+    snap set ladder userpass=myuser:mypassword
+
+  Then restart the service:
+
+    snap restart ladder
+
+  Point your browser at http://localhost:<port> once running.
+
   This snap is maintained by Alan Pope, and is not
   necessarily endorsed or officially maintained by the upstream developers.
 
@@ -25,6 +37,12 @@ grade: stable
 confinement: strict
 
 parts:
+  launcher:
+    plugin: dump
+    source: snap/local
+    organize:
+      ladder-launch: bin/ladder-launch
+
   ladder:
     plugin: make
     source: https://github.com/everywall/ladder
@@ -42,7 +60,7 @@ parts:
 
 apps:
   ladder:
-    command: ladder
+    command: bin/ladder-launch
     daemon: simple
     plugs:
       - network


### PR DESCRIPTION
Implements the feature requested in #1 — allow configuring `PORT` and `USERPASS` environment variables via `snap set`:

```bash
snap set ladder port=9090
snap set ladder userpass=myuser:mypassword
snap restart ladder
```

**How it works:**
- Adds a wrapper launcher script (`bin/ladder-launch`) that reads snap config via `snapctl get` and exports as environment variables before exec'ing the ladder binary
- Adds a `configure` hook that validates the port value and restarts the service when config changes
- Defaults to port 8080 if not set
- Updates description to document the configuration options

Closes #1