### PR TITLE
Update to 0.0.23 and add upstream sync

### DIFF
--- a/.github/workflows/sync-version-with-upstream.yml
+++ b/.github/workflows/sync-version-with-upstream.yml
@@ -1,0 +1,72 @@
+name: 🔄 Sync version with upstream
+
+on:
+  schedule:
+    - cron: '0 10 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get latest version from upstream
+        id: latest
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          LATEST_VERSION=$(gh release view --repo everywall/ladder --json tagName -q '.tagName' | tr -d 'v')
+          if [ -z "$LATEST_VERSION" ] || [ "$LATEST_VERSION" = "null" ]; then
+            echo "::error::Failed to fetch latest version from GitHub API"
+            exit 1
+          fi
+          echo "version=$LATEST_VERSION" >> "$GITHUB_OUTPUT"
+          echo "Latest upstream version: $LATEST_VERSION"
+
+      - name: Get current version from snapcraft.yaml
+        id: current
+        run: |
+          CURRENT_VERSION=$(grep "^version:" snap/snapcraft.yaml | head -1 | sed "s/version: *['\"]\{0,1\}\(.*\)['\"]\{0,1\}/\1/" | sed "s/['\"]//g")
+          echo "version=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
+          echo "Current snap version: $CURRENT_VERSION"
+
+      - name: Compare versions
+        id: compare
+        run: |
+          if [ "${{ steps.latest.outputs.version }}" != "${{ steps.current.outputs.version }}" ]; then
+            echo "needs_update=true" >> "$GITHUB_OUTPUT"
+            echo "Version mismatch - update needed"
+          else
+            echo "needs_update=false" >> "$GITHUB_OUTPUT"
+            echo "Versions match - no update needed"
+          fi
+
+      - name: Update snapcraft.yaml
+        if: steps.compare.outputs.needs_update == 'true'
+        run: |
+          sed -i "s/^version: .*/version: '${{ steps.latest.outputs.version }}'/" snap/snapcraft.yaml
+
+      - name: Create Pull Request
+        if: steps.compare.outputs.needs_update == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "Update to ${{ steps.latest.outputs.version }}"
+          title: "Update to ${{ steps.latest.outputs.version }}"
+          body: |
+            Automated version update from upstream.
+
+            - Previous: `${{ steps.current.outputs.version }}`
+            - New: `${{ steps.latest.outputs.version }}`
+
+            [Upstream release](https://github.com/everywall/ladder/releases/tag/v${{ steps.latest.outputs.version }})
+          branch: auto-update-${{ steps.latest.outputs.version }}
+          delete-branch: true

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: ladder
 title: Ladder
 base: core24
-version: '0.0.22'
+version: '0.0.23'
 license: GPL-3.0
 contact: https://github.com/popey/ladder-snap/issues
 issues: https://github.com/popey/ladder-snap/issues


### PR DESCRIPTION
This updates Ladder to upstream 0.0.23 and adds the scheduled/manual workflow used in other snap repos to keep `snap/snapcraft.yaml` in sync with upstream releases.

Changes:
- bump `version` in `snap/snapcraft.yaml` from `0.0.22` to `0.0.23`
- add `.github/workflows/sync-version-with-upstream.yml` to open future version bump PRs automatically

Notes:
- the repo already has a build workflow on PRs, so this should get normal snap validation there
- local `snapcraft --use-lxd` did not complete cleanly here because the ephemeral container stalled during `apt-get update`, before reaching the Ladder build stage